### PR TITLE
fix for redmine > 4.0 where author attribute is needed for new TimeEntry

### DIFF
--- a/app/controllers/work_time_controller.rb
+++ b/app/controllers/work_time_controller.rb
@@ -781,7 +781,7 @@ private
               append_text += " add time entry of ##{issue.id.to_s}: #{tm_vals[:hours].to_f}h"
               update_daily_memo(append_text, true)
             end
-            new_entry = TimeEntry.new(:project => issue.project, :issue => issue, :user => @this_user, :spent_on => @this_date)
+            new_entry = TimeEntry.new(:project => issue.project, :issue => issue, :author => User.current, :user => @this_user, :spent_on => @this_date)
             new_entry.safe_attributes = tm_vals
             new_entry.save
             append_error_message_html(@message, hour_update_check_error(new_entry, issue_id))


### PR DESCRIPTION
Redmine 4.2 compares if `author == user`. If not it automatically thinks that user edit work for someone else and plugin fails.
This PR fixes this behaviour.

Tested in Redmine 4.2