### PR TITLE
Add support for Redmine 6.0

### DIFF
--- a/app/controllers/work_time_controller.rb
+++ b/app/controllers/work_time_controller.rb
@@ -1,5 +1,4 @@
 class WorkTimeController < ApplicationController
-  unloadable
   #  before_filter :find_project, :authorize
   accept_api_auth :relay_total
 


### PR DESCRIPTION
`unloadable` isn't available in Rails 7. `unloadable` is needless for Redmine 5.1 or earlier. So we can remove `unloadable` safely.